### PR TITLE
Clarify date format to use ISO 8601 standard

### DIFF
--- a/.learn/exercises/04.1-date-range/README.md
+++ b/.learn/exercises/04.1-date-range/README.md
@@ -15,4 +15,4 @@ DatetimeIndex(['2021-05-01', '2021-05-02', '2021-05-03', '2021-05-04',
 
 ## 💡 Hint:
 
-+ In the date format you can use `DD-MM-YYYY` or `YYYY-MM-DD`.
++ Use the date format `YYYY-MM-DD` (ISO 8601), as it is the standard and avoids confusion. Other formats may not work as expected.


### PR DESCRIPTION
Updated the date format hint to specify ISO 8601.